### PR TITLE
fix: edit create post with promo logic

### DIFF
--- a/src/main/java/com/spring1/meliSocial/controller/PostController.java
+++ b/src/main/java/com/spring1/meliSocial/controller/PostController.java
@@ -26,7 +26,7 @@ public class PostController {
     @PostMapping("promo-post")
     public ResponseEntity<?> post(@RequestBody ProductPromoDto dto) {
         service.addNewProductPromo(dto);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return new ResponseEntity<>(new ResponseDto("Publicación con promoción creada"), HttpStatus.OK);
     }
 
     @GetMapping("followed/{userId}/list")

--- a/src/main/java/com/spring1/meliSocial/dto/request/ProductPromoDto.java
+++ b/src/main/java/com/spring1/meliSocial/dto/request/ProductPromoDto.java
@@ -1,6 +1,8 @@
 package com.spring1.meliSocial.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.spring1.meliSocial.dto.response.ProductDto;
 import com.spring1.meliSocial.model.Product;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -16,7 +18,7 @@ public class ProductPromoDto {
     private int userId;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy")
     private LocalDate date;
-    private Product product;
+    private ProductDto product;
     private int category;
     private double price; //precio original
     private boolean hasPromo;

--- a/src/main/java/com/spring1/meliSocial/model/Post.java
+++ b/src/main/java/com/spring1/meliSocial/model/Post.java
@@ -20,6 +20,4 @@ public class Post {
     private double price;
     private boolean hasPromo;
     private double discount;
-
-
 }

--- a/src/main/java/com/spring1/meliSocial/repository/IProductRepository.java
+++ b/src/main/java/com/spring1/meliSocial/repository/IProductRepository.java
@@ -1,13 +1,15 @@
 package com.spring1.meliSocial.repository;
 
+import com.spring1.meliSocial.model.Post;
 import com.spring1.meliSocial.model.Product;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface IProductRepository {
 
-    Optional<Product> findId(Integer id);
+    boolean findId(Integer id);
 
     List<Product> getProducts();
+
+    void add(Product product);
 }

--- a/src/main/java/com/spring1/meliSocial/repository/impl/ProductRepository.java
+++ b/src/main/java/com/spring1/meliSocial/repository/impl/ProductRepository.java
@@ -2,6 +2,7 @@ package com.spring1.meliSocial.repository.impl;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.spring1.meliSocial.exception.BadRequestException;
 import com.spring1.meliSocial.model.Product;
 import com.spring1.meliSocial.repository.IProductRepository;
 import org.springframework.stereotype.Repository;
@@ -31,12 +32,9 @@ public class ProductRepository implements IProductRepository {
         products = objectMapper.readValue(file,new TypeReference<List<Product>>(){});
     }
 
-
     @Override
-    public Optional<Product> findId(Integer id) {
-        return products.stream()
-                .filter(p->p.getId()==id)
-                .findFirst();
+    public boolean findId(Integer id) {
+        return products.stream().anyMatch(x ->x.getId() == id);
     }
 
     @Override
@@ -44,4 +42,8 @@ public class ProductRepository implements IProductRepository {
         return products;
     }
 
+    @Override
+    public void add(Product product) {
+        products.add(product);
+    }
 }

--- a/src/main/java/com/spring1/meliSocial/service/impl/PostService.java
+++ b/src/main/java/com/spring1/meliSocial/service/impl/PostService.java
@@ -64,8 +64,7 @@ public class PostService implements IPostService {
     }
 
     public void saveNewProduct(Post post){
-        Optional<Product> idProduct= productRepository.findId(post.getProduct().getId());
-        if(idProduct.isPresent()){
+        if(productRepository.findId(post.getProduct().getId())){
             throw new ExistingDataException("El producto con el id " + post.getProduct().getId() + " ya existe");
         }
 
@@ -75,9 +74,10 @@ public class PostService implements IPostService {
 
     @Override
     public void addNewProductPromo(ProductPromoDto productDto) {
-        if(repository.findById(productDto.getId()))
+        if(productRepository.findId(productDto.getProduct().getId()))
             throw new BadRequestException("El id del producto ya existe");
 
+        productRepository.add(mapper.convertValue(productDto.getProduct(), Product.class));
         Post aux = this.mapper.convertValue(productDto, Post.class);
         repository.addNewProductPromo(aux);
     }


### PR DESCRIPTION
En este PR se hace un fix del servicio US0010.

Se agrega un mensaje para el caso 200 OK con exito de post con promo.
Se hace un fix en la logica que permitia crear multiples post con promo con el mismo producto id ya que no estabamos persistiendo en memoria la creacion.

Respuesta 200 sin mensaje de exito
<img width="1087" alt="Captura de pantalla 2024-12-16 a la(s) 4 34 06 p  m" src="https://github.com/user-attachments/assets/33444fd6-5844-4b6a-a65f-05db2f3f7eff" />

Respuesta 400, no permitia generar nuevas publicaciones con promo a pesar de cambiar el id del producto
<img width="1083" alt="Captura de pantalla 2024-12-16 a la(s) 4 34 17 p  m" src="https://github.com/user-attachments/assets/456c5998-ee9b-4a88-8938-7d3eca511bbe" />

Respuesta 200 despues de los cambios.
<img width="1083" alt="Captura de pantalla 2024-12-16 a la(s) 4 34 56 p  m" src="https://github.com/user-attachments/assets/947a77bf-ba7a-4c02-b269-43e016ea79d5" />

Respuesta 400 despues de los cambios ahora crea los productos y valida correctamente
<img width="1081" alt="Captura de pantalla 2024-12-16 a la(s) 4 35 04 p  m" src="https://github.com/user-attachments/assets/a7c04221-0e1c-4e3f-8848-ea8108e2d34a" />

Respuesta 200 permite crear nuevas publicaciones con promo
<img width="1080" alt="Captura de pantalla 2024-12-16 a la(s) 4 35 16 p  m" src="https://github.com/user-attachments/assets/d7caff1d-4ca0-401f-b991-4aaef80518ec" />

