### PR TITLE
fix: [US0010] edit create post with promo logic

### DIFF
--- a/src/main/java/com/spring1/meliSocial/controller/PostController.java
+++ b/src/main/java/com/spring1/meliSocial/controller/PostController.java
@@ -27,7 +27,7 @@ public class PostController {
     @PostMapping("promo-post")
     public ResponseEntity<?> post(@RequestBody ProductPromoDto dto) {
         service.addNewProductPromo(dto);
-        return new ResponseEntity<>(HttpStatus.OK);
+        return new ResponseEntity<>(new ResponseDto("Publicación con promoción creada"), HttpStatus.OK);
     }
 
     @GetMapping("followed/{userId}/list")

--- a/src/main/java/com/spring1/meliSocial/dto/request/ProductPromoDto.java
+++ b/src/main/java/com/spring1/meliSocial/dto/request/ProductPromoDto.java
@@ -1,5 +1,6 @@
 package com.spring1.meliSocial.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.spring1.meliSocial.model.Product;
 import lombok.AllArgsConstructor;
@@ -13,12 +14,14 @@ import java.time.LocalDate;
 @NoArgsConstructor
 public class ProductPromoDto {
     private int id;
+    @JsonAlias("user_id")
     private int userId;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "dd-MM-yyyy")
     private LocalDate date;
     private Product product;
     private int category;
-    private double price; //precio original
+    private double price;
+    @JsonAlias("has_promo")
     private boolean hasPromo;
     private double discount;
 }

--- a/src/main/java/com/spring1/meliSocial/repository/impl/PostRepository.java
+++ b/src/main/java/com/spring1/meliSocial/repository/impl/PostRepository.java
@@ -57,8 +57,10 @@ public class PostRepository implements IPostRepository {
     }
 
     @Override
-    public void addNewProductPromo(Post product) {
-        posts.add(product);
+    public void addNewProductPromo(Post post) {
+        int countId = lastId()+1;
+        post.setId(countId);
+        posts.add(post);
     }
 
     @Override


### PR DESCRIPTION
En este PR se soluciona un bug que no permitia persistir correctamente los post con promocion.

- El id autoincremental no estaba implementado.
- Habia un error en el mapeo de la request con el DTO.
- Se agrega un mensaje de exito para el caso cuando se crea un post.


Respuesta 200 del servicio de creacion de post con promocion.
<img width="1077" alt="Captura de pantalla 2024-12-17 a la(s) 9 22 36 a  m" src="https://github.com/user-attachments/assets/d15b55a2-8bd5-4ea1-aa6a-8ba2a82d8941" />

Respuesta 200 del index pero sin actualizar el count por error al guardar.
<img width="1077" alt="Captura de pantalla 2024-12-17 a la(s) 9 21 13 a  m" src="https://github.com/user-attachments/assets/5cad98cc-5362-46b5-b4ac-8193549c36d3" />

Respuesta 200 del servicio de creacion de post con promocion despues de los cambios.
<img width="1077" alt="Captura de pantalla 2024-12-17 a la(s) 9 22 36 a  m" src="https://github.com/user-attachments/assets/d15b55a2-8bd5-4ea1-aa6a-8ba2a82d8941" />

Respuesta 200 del index ahora si persiste el post correctamente despues de los cambios.
<img width="1083" alt="Captura de pantalla 2024-12-17 a la(s) 9 21 52 a  m" src="https://github.com/user-attachments/assets/587d00f6-a5b7-4b43-8188-6369b0e323ca" />
