### PR TITLE
fix: cambio metodos http de posts favoritos

### DIFF
--- a/src/main/java/com/spring1/meliSocial/controller/UserController.java
+++ b/src/main/java/com/spring1/meliSocial/controller/UserController.java
@@ -43,14 +43,15 @@ public class UserController {
         return new ResponseEntity<>(userService.followUser(userId, userIdToFollow), HttpStatus.OK);
     }
 
-    @PatchMapping("{userId}/favourite-post/{postId}/add")
+    @PostMapping("{userId}/favourite-post/{postId}")
     public ResponseEntity<?> addFavouritePost(@PathVariable int userId, @PathVariable int postId){
         return new ResponseEntity<>(userService.addFavouritePost(userId, postId), HttpStatus.OK);
     }
 
-    @PatchMapping("{userId}/favourite-post/{postId}/remove")
+    @DeleteMapping("{userId}/favourite-post/{postId}")
     public ResponseEntity<?> removeFavouritePost(@PathVariable int userId, @PathVariable int postId){
-        return new ResponseEntity<>(userService.removeFavouritePost(userId, postId), HttpStatus.OK);
+        userService.removeFavouritePost(userId, postId);
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("{userId}/favourite-post")

--- a/src/main/java/com/spring1/meliSocial/service/IUserService.java
+++ b/src/main/java/com/spring1/meliSocial/service/IUserService.java
@@ -18,7 +18,7 @@ public interface IUserService {
 
     ResponseDto addFavouritePost(int userId, int postId);
 
-    ResponseDto removeFavouritePost(int userId, int postId);
+    void removeFavouritePost(int userId, int postId);
 
     FavouritePostsDto getFavouritePostsFromUser(int userId);
 }

--- a/src/main/java/com/spring1/meliSocial/service/impl/UserService.java
+++ b/src/main/java/com/spring1/meliSocial/service/impl/UserService.java
@@ -179,7 +179,7 @@ public class UserService implements IUserService {
     }
 
     @Override
-    public ResponseDto removeFavouritePost(int userId, int postId) {
+    public void removeFavouritePost(int userId, int postId) {
         if (!userRepository.existsUserWithId(userId)) {
             throw new NotFoundException("El usuario con ID: " + userId + " no existe.");
         }
@@ -190,8 +190,6 @@ public class UserService implements IUserService {
         }
 
         userRepository.removeFavouritePost(userId, postId);
-
-        return new ResponseDto("El post fue removido de favoritos de forma exitosa");
     }
 
     @Override

--- a/src/main/resources/SocialMeli.postman_collection.json
+++ b/src/main/resources/SocialMeli.postman_collection.json
@@ -260,18 +260,18 @@
 				{
 					"name": "US00014 - Add favourite post",
 					"request": {
-						"method": "PATCH",
+						"method": "POST",
 						"header": [],
-						"url": "{{base_url}}/users/1/favourite-post/2/add"
+						"url": "{{base_url}}/users/1/favourite-post/2"
 					},
 					"response": []
 				},
 				{
 					"name": "US00014 - Remove favourite post",
 					"request": {
-						"method": "PATCH",
+						"method": "DELETE",
 						"header": [],
-						"url": "{{base_url}}/users/1/favourite-post/2/remove"
+						"url": "{{base_url}}/users/1/favourite-post/2"
 					},
 					"response": []
 				},


### PR DESCRIPTION
* Se actualizaron los métodos https de los endpoints de agregado y borrado de posts favoritos. Se cambió de métodos PATCH a métodos POST y DELETE respectivamente.
* Se actualizó la collection de postman para reflejar estos cambios, ya que se modificaron tantos los métodos HTTP como la ruta de los endpoint
* El endpoint de POST mantendrá el mismo comportamiento y devolución de body de respuesta
* El endpoint de DELETE variará en su status code de retorno: Pasa de un 200 OK a un 204 No content y no devuelve ningún body